### PR TITLE
Fix backend layout title

### DIFF
--- a/Configuration/Sets/SitePackage/PageTsConfig/BackendLayouts/default.tsconfig
+++ b/Configuration/Sets/SitePackage/PageTsConfig/BackendLayouts/default.tsconfig
@@ -5,7 +5,7 @@ mod {
     web_layout {
         BackendLayouts {
             default {
-                title = LLL:EXT:site_package/Resources/Private/Language/locallang_be.xlf:backend_layout.example
+                title = LLL:EXT:site_package/Resources/Private/Language/locallang_be.xlf:backend_layout.default
                 config {
                     backend_layout {
                         colCount = 1


### PR DESCRIPTION
`backend_layout.example` is not defined in the language file and is therefore not visible in the backend.